### PR TITLE
Stabilize startup and add 1kHz dummy measurement/recording E2E checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .DS_Store
+outputs/

--- a/PyQt4/Qt.py
+++ b/PyQt4/Qt.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""
+Qt shim to let legacy PyQt4-style imports run on top of PySide6.
+This provides commonly used classes and functions with minimal coverage
+for this project (signals via old-style strings, QMessageBox, QFileDialog,
+QApplication, QWidget, QFrame, QPen, QFont, QColor, QRect, QPoint, etc.).
+"""
+from PySide6 import QtCore, QtGui, QtWidgets
+
+# Expose common namespaces under a single module like PyQt4.Qt
+Qt = QtCore.Qt
+
+# Widgets commonly referenced
+QApplication = QtWidgets.QApplication
+QApplication.UnicodeUTF8 = object()
+
+
+def _qt4_translate(context, text, disambiguation=None, encoding=None):
+    # PyQt4 used a four-argument translate that accepted an encoding flag.
+    # Qt6 dropped the encoding parameter, so ignore it here for compatibility.
+    if disambiguation is None:
+        return QtCore.QCoreApplication.translate(context, text)
+    return QtCore.QCoreApplication.translate(context, text, disambiguation)
+
+
+QApplication.translate = staticmethod(_qt4_translate)
+QWidget = QtWidgets.QWidget
+QDialog = QtWidgets.QDialog
+QMainWindow = QtWidgets.QMainWindow
+QMessageBox = QtWidgets.QMessageBox
+QFileDialog = QtWidgets.QFileDialog
+QFrame = QtWidgets.QFrame
+QProgressBar = QtWidgets.QProgressBar
+QLabel = QtWidgets.QLabel
+QPen = QtGui.QPen
+QFont = QtGui.QFont
+QColor = QtGui.QColor
+QRect = QtCore.QRect
+QPoint = QtCore.QPoint
+QSize = QtCore.QSize
+QDir = QtCore.QDir
+QTableView = QtWidgets.QTableView
+QHeaderView = QtWidgets.QHeaderView
+QAbstractItemView = QtWidgets.QAbstractItemView
+QStyledItemDelegate = QtWidgets.QStyledItemDelegate
+QComboBox = QtWidgets.QComboBox
+QPlainTextEdit = QtWidgets.QPlainTextEdit
+QSpinBox = QtWidgets.QSpinBox
+QDoubleSpinBox = QtWidgets.QDoubleSpinBox
+QAbstractTableModel = QtCore.QAbstractTableModel
+QModelIndex = QtCore.QModelIndex
+
+
+class QMetaType:
+    Bool = 1
+    QString = 2
+
+
+class QVariant:
+    def __init__(self, value=None):
+        self._value = value
+
+    def isValid(self):
+        return self._value is not None
+
+    def type(self):
+        v = self._value
+        if isinstance(v, bool):
+            return QMetaType.Bool
+        # treat everything else as non-bool (string/number)
+        return QMetaType.QString
+
+    def toBool(self):
+        return bool(self._value)
+
+    def toInt(self):
+        try:
+            return int(self._value), True
+        except Exception:
+            return 0, False
+
+    def toDouble(self):
+        try:
+            return float(self._value), True
+        except Exception:
+            return 0.0, False
+
+    def toString(self):
+        return str(self._value)
+
+    def toStringList(self):
+        if isinstance(self._value, (list, tuple)):
+            return [str(x) for x in self._value]
+        return []
+
+
+class _QStringHelper(str):
+    @staticmethod
+    def number(n):
+        return str(n)
+
+    def toFloat(self):
+        try:
+            return float(self), True
+        except Exception:
+            return 0.0, False
+
+    def toDouble(self):
+        return self.toFloat()
+
+    def toInt(self):
+        try:
+            return int(float(self)), True
+        except Exception:
+            return 0, False
+
+QString = _QStringHelper  # legacy alias
+
+
+def _wrap_qstring_return(func):
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        if isinstance(result, str) and not isinstance(result, _QStringHelper):
+            return _QStringHelper(result)
+        return result
+    return wrapper
+
+
+for _cls, _methods in (
+    (QtWidgets.QComboBox, ('currentText', 'itemText')),
+    (QtWidgets.QLineEdit, ('text', 'displayText')),
+):
+    for _name in _methods:
+        if hasattr(_cls, _name):
+            setattr(_cls, _name, _wrap_qstring_return(getattr(_cls, _name)))
+
+# Version string expected by legacy code
+try:
+    QT_VERSION_STR = QtCore.qVersion()
+except Exception:
+    QT_VERSION_STR = "6"
+
+# Old-style SIGNAL/SLOT compatibility
+class _SignalProxy(object):
+    def __init__(self, obj):
+        self._obj = obj
+
+    def __call__(self, signature):
+        # Return a wrapper that emits via dynamic signal map
+        # We create/lookup a QtCore.Signal dynamically on the instance
+        name = signature.split('(')[0]
+        # Maintain a map on the object
+        if not hasattr(self._obj, "__legacy_signals__"):
+            self._obj.__legacy_signals__ = {}
+        signals = self._obj.__legacy_signals__
+        if name not in signals:
+            # Create a Python signal using QObject's meta-object is non-trivial at runtime.
+            # Instead, we emulate emit/connect using a list of python callables.
+            signals[name] = []
+        
+        class _Emitter(object):
+            def __init__(self, obj, name):
+                self._obj = obj
+                self._name = name
+
+            def connect(self, slot):
+                self._obj.__legacy_signals__[self._name].append(slot)
+
+            def emit(self, *args, **kwargs):
+                for cb in list(self._obj.__legacy_signals__.get(self._name, [])):
+                    cb(*args, **kwargs)
+
+        return _Emitter(self._obj, name)
+
+
+def SIGNAL(signature):
+    try:
+        return QtCore.SIGNAL(signature)
+    except AttributeError:
+        return signature
+
+
+def SLOT(signature):
+    try:
+        return QtCore.SLOT(signature)
+    except AttributeError:
+        return signature
+
+
+class QObject(QtCore.QObject):
+    # Provide legacy helpers only if needed; native PySide6 connect/emit usually works
+    def emit(self, signal, *args):
+        # best-effort legacy emit when used with string signatures
+        if not hasattr(self, 'SIGNAL'):
+            self.SIGNAL = _SignalProxy(self)
+        self.SIGNAL(signal).emit(*args)
+
+    def connect(self, obj, signal, slot):  # noqa: A003 - keep legacy name
+        if isinstance(signal, str):
+            if not hasattr(obj, 'SIGNAL'):
+                obj.SIGNAL = _SignalProxy(obj)
+            obj.SIGNAL(signal).connect(slot)
+            return True
+        if hasattr(signal, 'connect'):
+            signal.connect(slot)
+            return True
+        raise AttributeError("Unsupported signal type: %r" % (signal,))
+
+
+# Patch PySide6 QObject with legacy helpers
+QtCore.QObject.emit = QObject.emit
+QtCore.QObject.connect = QObject.connect
+
+
+# Inject mixin behavior into key widgets so .connect/.emit is available
+# Avoid altering Qt class hierarchies to prevent instability
+
+# Namespace shortcuts expected by code
+class QStringList(list):
+    def __init__(self, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], str):
+            super(QStringList, self).__init__([args[0]])
+        else:
+            super(QStringList, self).__init__(*args, **kwargs)
+
+QDir = QtCore.QDir
+
+# Re-export submodules for import style from PyQt4 import Qt; then Qt.Qt etc.
+__all__ = [
+    'Qt', 'QApplication', 'QWidget', 'QDialog', 'QMainWindow', 'QMessageBox', 'QFileDialog',
+    'QFrame', 'QProgressBar', 'QLabel', 'QPen', 'QFont', 'QColor', 'QRect', 'QPoint', 'QDir',
+    'QTableView', 'QHeaderView', 'QAbstractItemView', 'QStyledItemDelegate', 'QComboBox',
+    'QPlainTextEdit', 'QSpinBox', 'QDoubleSpinBox', 'QAbstractTableModel', 'QModelIndex',
+    'QObject', 'SIGNAL', 'SLOT', 'QT_VERSION_STR', 'QString', 'QStringList', 'QMetaType', 'QVariant'
+]

--- a/PyQt4/Qt.py
+++ b/PyQt4/Qt.py
@@ -225,6 +225,15 @@ class QStringList(list):
 
 QDir = QtCore.QDir
 
+
+def __getattr__(name):
+    # Fallback lookup so legacy code can access additional Qt classes via
+    # `from PyQt4 import Qt; Qt.QVBoxLayout` style.
+    for module in (QtWidgets, QtGui, QtCore):
+        if hasattr(module, name):
+            return getattr(module, name)
+    raise AttributeError("module 'PyQt4.Qt' has no attribute %r" % (name,))
+
 # Re-export submodules for import style from PyQt4 import Qt; then Qt.Qt etc.
 __all__ = [
     'Qt', 'QApplication', 'QWidget', 'QDialog', 'QMainWindow', 'QMessageBox', 'QFileDialog',

--- a/PyQt4/QtCore.py
+++ b/PyQt4/QtCore.py
@@ -1,0 +1,40 @@
+from PySide6.QtCore import *  # noqa: F401,F403
+
+
+class QVariant(object):  # minimal shim for Qt4 API
+    def __init__(self, value=None):
+        self._value = value
+
+    def isValid(self):
+        return self._value is not None
+
+    def type(self):
+        value = self._value
+        if isinstance(value, bool):
+            return 1
+        return 2
+
+    def toBool(self):
+        return bool(self._value)
+
+    def toInt(self):
+        try:
+            return int(self._value), True
+        except Exception:
+            return 0, False
+
+    def toDouble(self):
+        try:
+            return float(self._value), True
+        except Exception:
+            return 0.0, False
+
+    def toString(self):
+        return str(self._value)
+
+    def toStringList(self):
+        if isinstance(self._value, (list, tuple)):
+            return [str(x) for x in self._value]
+        return []
+
+

--- a/PyQt4/QtCore.py
+++ b/PyQt4/QtCore.py
@@ -38,3 +38,31 @@ class QVariant(object):  # minimal shim for Qt4 API
         return []
 
 
+class QString(str):
+    @staticmethod
+    def number(n):
+        return str(n)
+
+    def toFloat(self):
+        try:
+            return float(self), True
+        except Exception:
+            return 0.0, False
+
+    def toDouble(self):
+        return self.toFloat()
+
+    def toInt(self):
+        try:
+            return int(float(self)), True
+        except Exception:
+            return 0, False
+
+
+class QStringList(list):
+    def __init__(self, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], str):
+            super(QStringList, self).__init__([args[0]])
+        else:
+            super(QStringList, self).__init__(*args, **kwargs)
+

--- a/PyQt4/QtGui.py
+++ b/PyQt4/QtGui.py
@@ -1,0 +1,5 @@
+from PySide6.QtWidgets import *  # noqa: F401,F403
+from PySide6.QtGui import *  # noqa: F401,F403
+
+
+

--- a/PyQt4/Qwt5.py
+++ b/PyQt4/Qwt5.py
@@ -31,6 +31,8 @@ class QwtText:
         self._text = str(text)
         self._color = QtGui.QColor('black')
         self._font = QtGui.QFont()
+    def setText(self, text):
+        self._text = str(text)
     def setFont(self, f):
         self._font = f
     def setColor(self, c):
@@ -42,6 +44,7 @@ class QwtText:
 
 
 class QwtPlot(pg.PlotWidget):
+    xTop = 2
     xBottom = 0
     yLeft = 1
     LeftLegend = 0
@@ -117,8 +120,23 @@ class QwtPlotCurve(pg.PlotDataItem):
         super(QwtPlotCurve, self).__init__(x=[], y=[])
         self._title = title
         self._style = self.Lines
+        self._pen_color = QtGui.QColor('white')
+    class _PenProxy:
+        def __init__(self, color):
+            self.color = color
+    def pen(self):
+        return self._PenProxy(self._pen_color)
     def setPen(self, pen):
-        color = pen.color()
+        if hasattr(pen, 'color'):
+            if callable(pen.color):
+                color = pen.color()
+            else:
+                color = pen.color
+        else:
+            color = pen
+        if not isinstance(color, QtGui.QColor):
+            color = QtGui.QColor(color)
+        self._pen_color = color
         super(QwtPlotCurve, self).setPen(pg.mkPen(color))
     def setYAxis(self, axis):
         pass

--- a/PyQt4/Qwt5.py
+++ b/PyQt4/Qwt5.py
@@ -1,0 +1,221 @@
+# Very small Qwt5 compatibility shim using pyqtgraph for plotting.
+# Only covers what display.py/impedance.py need.
+
+import pyqtgraph as pg
+from PySide6 import QtWidgets, QtGui, QtCore
+
+QWT_VERSION_STR = "5.99-shim"
+
+class QwtLegend(QtWidgets.QListWidget):
+    ClickableItem = 1
+    def __init__(self, *args):
+        super(QwtLegend, self).__init__(*args)
+        self._items = []
+    def setItemMode(self, mode):
+        pass
+    def legendItems(self):
+        return self._items
+    def itemCount(self):
+        return len(self._items)
+    def contentsWidget(self):
+        return self
+    def verticalScrollBar(self):
+        return self
+    def sizeHint(self):
+        return super().sizeHint()
+
+
+class QwtText:
+    PaintUsingTextFont = 1
+    def __init__(self, text=''):
+        self._text = str(text)
+        self._color = QtGui.QColor('black')
+        self._font = QtGui.QFont()
+    def setFont(self, f):
+        self._font = f
+    def setColor(self, c):
+        self._color = c
+    def setPaintAttribute(self, attr):
+        pass
+    def text(self):
+        return self._text
+
+
+class QwtPlot(pg.PlotWidget):
+    xBottom = 0
+    yLeft = 1
+    LeftLegend = 0
+    def __init__(self, *args, **kwargs):
+        super(QwtPlot, self).__init__(*args, **kwargs)
+        self._legend = QwtLegend()
+        self._grid = None
+    def setCanvasBackground(self, color):
+        if isinstance(color, (tuple, list)) and color:
+            color = color[0]
+        if not isinstance(color, QtGui.QColor):
+            color = QtGui.QColor(color)
+        self.setBackground(color)
+    def insertLegend(self, legend, where):
+        self._legend = legend
+    def legend(self):
+        return self._legend
+    def setAxisTitle(self, axis, title):
+        pass
+    def setAxisMaxMajor(self, axis, val):
+        pass
+    def setAxisMaxMinor(self, axis, val):
+        pass
+    def setAxisFont(self, axis, font):
+        pass
+    def setAxisScaleDraw(self, axis, draw):
+        pass
+    def enableAxis(self, axis, on):
+        pass
+    def setAxisScale(self, axis, vmin, vmax, step=None):
+        if axis == self.xBottom:
+            self.setXRange(vmin, vmax)
+        else:
+            self.setYRange(vmin, vmax)
+    def plotLayout(self):
+        return self
+    def canvasMargin(self, which):
+        return 0
+    def replot(self):
+        self.repaint()
+    def axisScaleDiv(self, axis):
+        class _R: 
+            def range(self):
+                return 10.0
+        return _R()
+
+
+class QwtPlotGrid:
+    def __init__(self):
+        pass
+    def enableY(self, on):
+        pass
+    def enableX(self, on):
+        pass
+    def enableXMin(self, on):
+        pass
+    def setMajPen(self, pen):
+        pass
+    def setMinPen(self, pen):
+        pass
+    def attach(self, plot):
+        plot._grid = self
+
+
+class QwtPlotCurve(pg.PlotDataItem):
+    PaintFiltered = 1
+    Lines = 0
+    Sticks = 1
+    NoCurve = 2
+    def __init__(self, title=None):
+        if title is None:
+            title = QwtText('')
+        super(QwtPlotCurve, self).__init__(x=[], y=[])
+        self._title = title
+        self._style = self.Lines
+    def setPen(self, pen):
+        color = pen.color()
+        super(QwtPlotCurve, self).setPen(pg.mkPen(color))
+    def setYAxis(self, axis):
+        pass
+    def setPaintAttribute(self, attr):
+        pass
+    def attach(self, plot):
+        plot.addItem(self)
+    def detach(self):
+        self.setVisible(False)
+    def title(self):
+        return self._title
+    def setTitle(self, t):
+        self._title = t
+    def setData(self, x, y):
+        super().setData(x, y)
+    def setStyle(self, style):
+        self._style = style
+        if style == self.Sticks:
+            try:
+                self.setFillLevel(0)
+            except Exception:
+                pass
+        else:
+            try:
+                self.setFillLevel(None)
+            except Exception:
+                pass
+
+
+class QwtSymbol:
+    VLine = 1
+    def __init__(self):
+        self._style = None
+        self._size = 10
+    def setStyle(self, s):
+        self._style = s
+    def setSize(self, s):
+        self._size = s
+
+
+class QwtPlotMarker(pg.InfiniteLine):
+    NoLine = 0
+    def __init__(self):
+        super(QwtPlotMarker, self).__init__(angle=90)
+        self.sampleCounter = 0
+    def setLabel(self, txt):
+        pass
+    def setLabelAlignment(self, align):
+        pass
+    def setLineStyle(self, style):
+        pass
+    def setXValue(self, x):
+        self.setPos(x)
+    def setYValue(self, y):
+        pass
+    def setSymbol(self, sym):
+        pass
+    def attach(self, plot):
+        plot.addItem(self)
+    def detach(self):
+        self.setVisible(False)
+
+
+class QwtScaleDraw:
+    RightScale = 0
+    def __init__(self, *args):
+        pass
+    @staticmethod
+    def invalidateCache(obj):
+        pass
+
+
+class QwtScaleDiv:
+    def __init__(self, vmin, vmax, a, ticks, b):
+        self._vmin = vmin
+        self._vmax = vmax
+        self._ticks = ticks
+
+
+class QwtPlotScaleItem:
+    def __init__(self, where):
+        self._div = None
+    def setBorderDistance(self, d):
+        pass
+    def attach(self, plot):
+        pass
+    def setScaleDiv(self, div):
+        self._div = div
+
+
+QwtText = QwtText
+QwtPlot = QwtPlot
+QwtPlotGrid = QwtPlotGrid
+QwtPlotCurve = QwtPlotCurve
+QwtSymbol = QwtSymbol
+QwtPlotMarker = QwtPlotMarker
+QwtScaleDraw = QwtScaleDraw
+QwtScaleDiv = QwtScaleDiv
+QwtPlotScaleItem = QwtPlotScaleItem
+QwtLegend = QwtLegend

--- a/PyQt4/__init__.py
+++ b/PyQt4/__init__.py
@@ -1,0 +1,25 @@
+# Minimal PyQt4 compatibility layer backed by PySide6
+
+from . import Qt as Qt  # re-export Qt shim
+
+# Optional submodules for legacy imports
+from . import QtCore as QtCore  # noqa: F401
+from . import QtGui as QtGui    # noqa: F401
+
+# Provide uic compatibility
+from . import uic as uic  # noqa: F401
+
+# Qwt5 shim (very minimal)
+from . import Qwt5 as Qwt5  # noqa: F401
+
+__all__ = [
+    "Qt",
+    "QtCore",
+    "QtGui",
+    "uic",
+    "Qwt5",
+]
+
+
+
+

--- a/PyQt4/uic.py
+++ b/PyQt4/uic.py
@@ -1,0 +1,11 @@
+from PySide6 import QtUiTools
+
+def compileUi(ui_filename, fp):
+    loader = QtUiTools.QUiLoader()
+    # We cannot compile to python; emulate by writing a minimal stub or raising.
+    # For this project, .py files already exist in res/. If needed, we fallback.
+    raise NotImplementedError("uic.compileUi is not supported in this shim. Use generated .py files.")
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Quick start:
   - `bash ./run_pycorder.sh --smoketest`
 - Automated GUI measurement check with dummy data (headless/offscreen, validates 1000 Hz by default):
   - `QT_QPA_PLATFORM=offscreen .venv/bin/python tools/gui_dummy_measurement_check.py`
+- Automated end-to-end check (measurement + file creation in one run):
+  - `QT_QPA_PLATFORM=offscreen .venv/bin/python tools/gui_dummy_recording_check.py --sample-rate-hz 1000 --duration-ms 2600`
 
 GUI startup (recommended):
 - macOS/Linux:
@@ -57,6 +59,16 @@ Validate 1000 Hz dummy acquisition (automated):
 
 You can test other rates similarly, for example:
 - `QT_QPA_PLATFORM=offscreen .venv/bin/python tools/gui_dummy_measurement_check.py --sample-rate-hz 2000 --duration-ms 2600`
+
+Validate one-shot measurement + recording file creation:
+1. Run:
+   - `QT_QPA_PLATFORM=offscreen .venv/bin/python tools/gui_dummy_recording_check.py --sample-rate-hz 1000 --duration-ms 2600`
+2. Confirm the output contains:
+   - `gui_recording_ok=True`
+   - `configured_rate=1000.0`
+   - `reported_rate=1000.0`
+3. Output files are created under:
+   - `outputs/dummy_recordings/` (`.eeg`, `.vhdr`, `.vmrk`)
 
 If GUI does not start:
 1. Run `bash ./run_pycorder.sh --smoketest` to verify dependency/runtime startup.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,47 @@ Quick start:
     - `python main.py`
 - Automated smoke test (headless, no window popup):
   - `bash ./run_pycorder.sh --smoketest`
+- Automated GUI measurement check with dummy data (headless/offscreen, validates 1000 Hz by default):
+  - `QT_QPA_PLATFORM=offscreen .venv/bin/python tools/gui_dummy_measurement_check.py`
+
+GUI startup (recommended):
+- macOS/Linux:
+  1. `bash ./run_pycorder.sh`
+  2. Wait until the PyCorder main window opens.
+- Windows PowerShell:
+  1. `.\run_pycorder.ps1`
+  2. Wait until the PyCorder main window opens.
+- Windows CMD:
+  1. `run_pycorder.bat`
+  2. Wait until the PyCorder main window opens.
+
+Dummy data measurement (no hardware):
+1. Start GUI with one of the commands above.
+2. In the amplifier online pane, click `Default` (start acquisition).
+3. Confirm waveform updates in the display pane.
+4. Click again to stop acquisition.
+
+Validate 1000 Hz dummy acquisition (automated):
+1. Run:
+   - `QT_QPA_PLATFORM=offscreen .venv/bin/python tools/gui_dummy_measurement_check.py --sample-rate-hz 1000 --duration-ms 2600`
+2. Confirm the output contains:
+   - `gui_measurement_ok=True`
+   - `configured_rate=1000.0`
+   - `reported_rate=1000.0`
+
+You can test other rates similarly, for example:
+- `QT_QPA_PLATFORM=offscreen .venv/bin/python tools/gui_dummy_measurement_check.py --sample-rate-hz 2000 --duration-ms 2600`
+
+If GUI does not start:
+1. Run `bash ./run_pycorder.sh --smoketest` to verify dependency/runtime startup.
+2. If another instance is still running, stop it:
+   - `pkill -f "python.*main.py"`
+3. Run `QT_QPA_PLATFORM=offscreen .venv/bin/python tools/gui_dummy_measurement_check.py --sample-rate-hz 1000` to verify dummy acquisition path.
+
+Notes:
+- On macOS, PyCorder uses a stable simple scope (`DISP_ScopeSimple`) by default to avoid Qt/Qwt shim startup crashes while still showing live dummy/hardware waveforms.
+- If the selected scope widget cannot be initialized on your Qt runtime, PyCorder falls back to a minimal pane (`DISP_ScopeLite`) so acquisition can still run.
+- If TCP port `51244` is already in use, the RDA server module is skipped and the GUI still starts.
 
 Current additions:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
 # PyCorder
 Modified PyCorder Code for EIT Experiments
 
+Compatibility updates (2025):
+- Python 3.x compatible (print, queue, configparser, perf_counter)
+- macOS (Apple Silicon/Intel) and Windows 11: runs in GUI with fallback simulation when ActiChamp DLL is absent
+- File I/O uses Python standard API (no libc dependency)
+- Legacy PyQt4/PyQwt imports are shimmed to PySide6/pyqtgraph (`PyQt4/` directory)
+
+Requirements:
+- Python 3.9+
+- numpy, scipy, lxml
+- PySide6, pyqtgraph
+
+Quick start:
+- Windows with hardware: install vendor DLLs in the working directory (`ActiChamp_x64.dll`/`ActiChamp_x86.dll`)
+- macOS/No hardware: app starts in simulation mode automatically
+- First run on macOS/Linux (or when `.venv` is broken): `bash ./run_pycorder.sh`
+- First run on Windows PowerShell: `.\run_pycorder.ps1`
+- First run on Windows CMD: `run_pycorder.bat`
+- Manual run after setup:
+  - macOS/Linux:
+    - `source .venv/bin/activate`
+    - `python main.py`
+  - Windows:
+    - `.venv\Scripts\activate`
+    - `python main.py`
+- Automated smoke test (headless, no window popup):
+  - `bash ./run_pycorder.sh --smoketest`
+
 Current additions:
 
 DC Offset pane shows the DC voltage on each electrode

--- a/amplifier.py
+++ b/amplifier.py
@@ -711,7 +711,7 @@ class AMP_ActiChamp(ModuleBase):
         ''' Get data from amplifier
         and return the eeg data block
         '''
-        t = time.clock()
+        t = time.perf_counter()
         self.eeg_data.performance_timer = 0
         self.eeg_data.performance_timer_max = 0
         self.recordtime = 0.0

--- a/custom_modules/dc_offset.py
+++ b/custom_modules/dc_offset.py
@@ -85,10 +85,10 @@ class dc_offset(ModuleBase):
         else:
             self.signalPane.show()
           
-          #set the Scale of the DC offset plot
+    # set the Scale of the DC offset plot
     def setDCScale(self):
-		scale = self.onlinePane.getCurrentValues()
-		self.signalPane.setScale(scale)
+        scale = self.onlinePane.getCurrentValues()
+        self.signalPane.setScale(scale)
 		
     def process_input(self, datablock):
         ''' Get data from previous module.
@@ -103,10 +103,9 @@ class dc_offset(ModuleBase):
         #but only if the pane is visible
         
         if self.signalPane.isVisible():
-     	    dc_offsets = np.mean(datablock.eeg_channels,1)/1000 #Convert from uV to mV
-     	    chan_indices = [x + 1 for x in range(datablock.channel_properties.shape[0])]
-     	    
-     	    self.signalPane.DCValues.setData(chan_indices,dc_offsets)
+            dc_offsets = np.mean(datablock.eeg_channels,1)/1000 #Convert from uV to mV
+            chan_indices = [x + 1 for x in range(datablock.channel_properties.shape[0])]
+            self.signalPane.DCValues.setData(chan_indices,dc_offsets)
             
             
     def process_output(self):
@@ -118,12 +117,12 @@ class dc_offset(ModuleBase):
         return self.data
 		
     def process_update(self, params):
-    	if params != None:
-        		#Set the width of the pen for DC offset plot based on the dimensions of the window
-		#and the number of channels
+        if params != None:
+            # Set the width of the pen for DC offset plot based on the dimensions of the window
+            # and the number of channels
             num_channels = params.channel_properties.shape[0]
-            frame_width = self.signalPane.width()	
-		#Calculate sensible value for line width, so that bars don't overlap
+            frame_width = self.signalPane.width()
+            # Calculate sensible value for line width, so that bars don't overlap
             new_pen_width = 0.9*frame_width/ (2*num_channels)
             self.signalPane.setLineWidth(new_pen_width)
 
@@ -136,9 +135,9 @@ class dc_offset(ModuleBase):
         return self.onlinePane
 		
     def get_display_pane(self):
-	''' Get the signal pane
-	@return: a QFrame object
-	'''
+        ''' Get the signal pane
+        @return: a QFrame object
+        '''
         return self.signalPane
     
 ################################################################
@@ -148,7 +147,7 @@ class _OnlineCfgPane(Qt.QFrame):
     ''' Online configuration pane
     '''
     def __init__(self , *args):
-        apply(Qt.QFrame.__init__, (self,) + args)
+        Qt.QFrame.__init__(self, *args)
 
         # make it nice ;-)
         self.setFrameShape(QtGui.QFrame.Panel)
@@ -194,7 +193,13 @@ class _OnlineCfgPane(Qt.QFrame):
         self.comboBoxScale.setCurrentIndex(1)
     
     def getCurrentValues(self):
-    	scale,ok = self.comboBoxScale.currentText().toFloat()
+        text = self.comboBoxScale.currentText()
+        try:
+            scale = float(text)
+            ok = True
+        except Exception:
+            scale = 1.0
+            ok = False
         return scale
        
 		################################################################
@@ -204,7 +209,7 @@ class  _SignalPane(Qt.QFrame):
     ''' FFT display pane
     '''
     def __init__(self , *args):
-        apply(Qt.QFrame.__init__, (self,) + args)
+        Qt.QFrame.__init__(self, *args)
 		
         self.setMinimumSize(Qt.QSize(200,50))
 
@@ -250,7 +255,6 @@ class  _SignalPane(Qt.QFrame):
         self.DCplot.setAxisScale(0,-scale,scale)
         
     def setLineWidth(self,width):
-    	
         self.DCValues.setPen(Qt.QPen(Qt.Qt.red, width, Qt.Qt.SolidLine))
 
     def timerEvent(self,e):

--- a/devices/devbase.py
+++ b/devices/devbase.py
@@ -86,7 +86,7 @@ class HardwareInputDevice():
         '''
         # get the required channel indices
         mask = lambda x: (x.inputgroup == self.inputGroup) and (x.input in self.inputChannels)
-        ch_map = np.array(map(mask, params.channel_properties))
+        ch_map = np.array([mask(ch) for ch in params.channel_properties], dtype=bool)
         indices = np.nonzero(ch_map)[0]     # indices of required channels
         # dictionary with channel number as key and its index in the input data array as value
         idx = dict((x.input, indices[i]) for i, x in enumerate(params.channel_properties[indices]))
@@ -138,7 +138,7 @@ class HardwareInputDevice():
         '''
         # the default implementation enables all output channels
         mask = lambda x: True
-        ch_map = np.array(map(mask, self.outputProperties))
+        ch_map = np.array([mask(ch) for ch in self.outputProperties], dtype=bool)
         # indices of enabled output channels
         indices = np.nonzero(ch_map)[0]     
         return indices
@@ -211,7 +211,7 @@ class HardwareInputDevice():
         # check version, has to be lower or equal than current version
         version = xml.get("version")
         if (version == None) or (int(version) > self.xmlVersion):
-            raise Exception, "Device %s wrong version > %d"%(self.deviceName, self.xmlVersion)
+            raise Exception("Device %s wrong version > %d"%(self.deviceName, self.xmlVersion))
         version = int(version)
         
         # get the values
@@ -252,7 +252,6 @@ class DeviceConfigDlg(Qt.QDialog):
 
         self.connect(self.buttonBox, Qt.SIGNAL("accepted()"), self.accept)
         self.connect(self.buttonBox, Qt.SIGNAL("rejected()"), self.reject)
-
 
 
 

--- a/devices/devcontainer.py
+++ b/devices/devcontainer.py
@@ -215,7 +215,7 @@ class DeviceContainer(Qt.QObject):
         # check version, has to be lower or equal than current version
         version = xml.InputDevices.get("version")
         if (version == None) or (int(version) > self.xmlVersion):
-            raise Exception, "Input Device Configuration: wrong version > %d"%(self.xmlVersion)
+            raise Exception("Input Device Configuration: wrong version > %d"%(self.xmlVersion))
         version = int(version)
         
         # get and instantiate the input devices
@@ -231,7 +231,7 @@ class DeviceContainer(Qt.QObject):
                 if not overlapping:
                     self.instantiatedDevices.append(d)
                 else:
-                    raise Exception, "Can't connect %s: "%(d.description)+"Required input channels are already in use by other devices"
+                    raise Exception("Can't connect %s: "%(d.description)+"Required input channels are already in use by other devices")
 
 
 

--- a/devices/epp.py
+++ b/devices/epp.py
@@ -77,7 +77,7 @@ class DeviceEpPreamp(HardwareInputDevice):
         @return: channel index array 
         '''
         mask = lambda x: x.gain != "off"
-        ch_map = np.array(map(mask, self.channelProperties))
+        ch_map = np.array([mask(ch) for ch in self.channelProperties], dtype=bool)
         # indices of enabled output channels
         indices = np.nonzero(ch_map)[0]     
         return indices
@@ -173,7 +173,7 @@ class DeviceEpPreamp(HardwareInputDevice):
         # check version, has to be lower or equal than current version
         version = xml.get("version")
         if (version == None) or (int(version) > self.xmlVersion):
-            raise Exception, "Device %s wrong version > %d"%(self.deviceName, self.xmlVersion)
+            raise Exception("Device %s wrong version > %d"%(self.deviceName, self.xmlVersion))
         version = int(version)
         
         # get the values
@@ -234,7 +234,6 @@ class EPPConfigDlg(Qt.QDialog):
 
         self.connect(self.buttonBox, Qt.SIGNAL("accepted()"), self.accept)
         self.connect(self.buttonBox, Qt.SIGNAL("rejected()"), self.reject)
-
 
 
 

--- a/display.py
+++ b/display.py
@@ -45,7 +45,7 @@ DISPLAY MODULE
 ------------------------------------------------------------
 '''
     
-class DISP_Scope(Qwt.QwtPlot, ModuleBase):
+class DISP_Scope(ModuleBase, Qwt.QwtPlot):
     """ EEG signal display widget.
     """
     def __init__(self, *args, **keys):
@@ -676,7 +676,8 @@ class _ScopeLegend(Qwt.QwtLegend):
     def __init__(self, *args):
         Qwt.QwtLegend.__init__(self, *args)
         layout = self.contentsWidget().layout()
-        layout.setSpacing(0)
+        if layout is not None:
+            layout.setSpacing(0)
     
     def heightForWidth(self, width):
         return 0
@@ -703,8 +704,9 @@ class _ScopeLegend(Qwt.QwtLegend):
             item.setFixedHeight(itemHeight)
             yBottom += itemHeight
         layout = self.contentsWidget().layout()
-        layout.setGeometry(Qt.QRect(Qt.QPoint(0,offset), 
-                                    Qt.QPoint(visibleSize.width(), visibleSize.height() -2 * offset)))
+        if layout is not None:
+            layout.setGeometry(Qt.QRect(Qt.QPoint(0,offset),
+                                        Qt.QPoint(visibleSize.width(), visibleSize.height() -2 * offset)))
         self.contentsWidget().resize(visibleSize.width(), visibleSize.height())
         return
 

--- a/display_fallback.py
+++ b/display_fallback.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Fallback display module used when the full scope widget cannot initialize."""
+
+from PyQt4 import Qt
+from PyQt4 import QtGui
+
+from modbase import ModuleBase
+
+
+class DISP_ScopeLite(ModuleBase):
+    """Minimal placeholder display pane.
+
+    Keeps the GUI usable when the Qwt/pyqtgraph-based scope cannot be created
+    in the current Qt binding/runtime.
+    """
+
+    def __init__(self, *args, **keys):
+        reason = keys.pop("reason", "")
+        ModuleBase.__init__(self, usethread=False, name="Display", **keys)
+
+        self._pane = Qt.QFrame()
+        self._pane.setObjectName("DisplayFallback")
+        self._pane.setFrameShape(Qt.QFrame.StyledPanel)
+        layout = QtGui.QVBoxLayout(self._pane)
+        layout.setContentsMargins(12, 12, 12, 12)
+
+        title = Qt.QLabel("Scope view is unavailable in this environment.")
+        title.setWordWrap(True)
+        layout.addWidget(title)
+
+        if reason:
+            detail = Qt.QLabel("Reason: %s" % (reason,))
+            detail.setWordWrap(True)
+            layout.addWidget(detail)
+
+        hint = Qt.QLabel("Acquisition and recording can continue using the other modules.")
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+        layout.addStretch(1)
+
+    def get_display_pane(self):
+        return self._pane
+
+    def process_input(self, datablock):
+        return
+
+    def process_output(self):
+        return None

--- a/display_simple.py
+++ b/display_simple.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""Stable pyqtgraph-based scope view used on platforms where Qwt shim is unstable."""
+
+from __future__ import annotations
+
+from PyQt4 import Qt
+import numpy as np
+import pyqtgraph as pg
+import threading
+
+from modbase import *
+
+
+class DISP_ScopeSimple(ModuleBase):
+    """Lightweight signal display.
+
+    This module focuses on stability: it plots a few channels from incoming
+    data and avoids the legacy Qwt API surface.
+    """
+
+    def __init__(self, *args, **keys):
+        ModuleBase.__init__(self, usethread=True, name="Display", **keys)
+
+        self._pane = Qt.QFrame()
+        self._pane.setObjectName("DisplaySimple")
+        self._pane.setMinimumSize(Qt.QSize(400, 200))
+        layout = Qt.QVBoxLayout(self._pane)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.plot = pg.PlotWidget()
+        self.plot.setBackground("w")
+        self.plot.showGrid(x=True, y=True, alpha=0.25)
+        self.plot.setLabel("bottom", "Samples")
+        self.plot.setLabel("left", "Amplitude (uV)")
+        layout.addWidget(self.plot)
+
+        self._lock = threading.Lock()
+        self._sample_rate = 500.0
+        self._max_channels = 8
+        self._history_samples = 4000
+        self._pending = None
+        self._buffer = None
+        self._curves = []
+        self._curve_colors = ["#005f73", "#0a9396", "#ee9b00", "#ca6702",
+                              "#bb3e03", "#ae2012", "#9b2226", "#3a86ff"]
+        self._update_requested = False
+        self.startTimer(50)
+
+    def get_display_pane(self):
+        return self._pane
+
+    def process_update(self, params):
+        if params is not None:
+            self._sample_rate = float(getattr(params, "sample_rate", 500.0))
+            channel_count = min(len(params.channel_properties), self._max_channels)
+            with self._lock:
+                if channel_count <= 0:
+                    self._buffer = np.zeros((0, self._history_samples), dtype=float)
+                else:
+                    self._buffer = np.zeros((channel_count, self._history_samples), dtype=float)
+                self._pending = None
+                self._update_requested = True
+            self._ensure_curves(channel_count)
+        return params
+
+    def process_start(self):
+        with self._lock:
+            if self._buffer is not None:
+                self._buffer[:] = 0.0
+            self._pending = None
+            self._update_requested = True
+
+    def process_input(self, datablock):
+        if datablock is None:
+            return
+        if datablock.recording_mode == RecordingMode.IMPEDANCE:
+            return
+
+        data = np.asarray(datablock.eeg_channels, dtype=float)
+        if data.ndim != 2 or data.shape[1] == 0:
+            return
+        channels = min(data.shape[0], self._max_channels)
+        if channels <= 0:
+            return
+
+        with self._lock:
+            if self._buffer is None or self._buffer.shape[0] != channels:
+                self._buffer = np.zeros((channels, self._history_samples), dtype=float)
+                self._ensure_curves(channels)
+            self._pending = data[:channels].copy()
+            self._update_requested = True
+
+    def process_output(self):
+        return None
+
+    def timerEvent(self, _event):
+        if not self._update_requested:
+            return
+        with self._lock:
+            pending = self._pending
+            self._pending = None
+            buffer = self._buffer
+            self._update_requested = False
+        if buffer is None or buffer.size == 0:
+            return
+        if pending is not None and pending.size > 0:
+            n = pending.shape[1]
+            if n >= buffer.shape[1]:
+                buffer[:] = pending[:, -buffer.shape[1]:]
+            else:
+                buffer[:, :-n] = buffer[:, n:]
+                buffer[:, -n:] = pending
+        self._redraw(buffer)
+
+    def _ensure_curves(self, channel_count):
+        while len(self._curves) < channel_count:
+            idx = len(self._curves)
+            color = self._curve_colors[idx % len(self._curve_colors)]
+            curve = self.plot.plot(pen=pg.mkPen(color, width=1))
+            self._curves.append(curve)
+        while len(self._curves) > channel_count:
+            curve = self._curves.pop()
+            self.plot.removeItem(curve)
+
+    def _redraw(self, buffer):
+        x = np.arange(buffer.shape[1], dtype=float)
+        spacing = 200.0
+        for idx, curve in enumerate(self._curves):
+            y = buffer[idx] + (len(self._curves) - idx - 1) * spacing
+            curve.setData(x, y)

--- a/filter.py
+++ b/filter.py
@@ -323,7 +323,7 @@ class _ConfigurationPane(Qt.QFrame, frmFilterConfig.Ui_frmFilterConfig):
     def __init__(self, filter, *args):
         ''' Constructor
         '''
-        apply(Qt.QFrame.__init__, (self,) + args)
+        Qt.QFrame.__init__(self, *args)
         self.setupUi(self)
         self.tableView.horizontalHeader().setResizeMode(Qt.QHeaderView.ResizeToContents)
 
@@ -391,7 +391,7 @@ class _ConfigurationPane(Qt.QFrame, frmFilterConfig.Ui_frmFilterConfig):
         '''
         # AUX channel table
         mask = lambda x: x.group != ChannelGroup.EEG
-        ch_map = np.array(map(mask, self.filter.params.channel_properties))
+        ch_map = np.array([mask(ch) for ch in self.filter.params.channel_properties], dtype=bool)
         ch_indices = np.nonzero(ch_map)[0]     
         self.table_model = _ConfigTableModel(self.filter.params.channel_properties[ch_indices])
         self.tableView.setModel(self.table_model)
@@ -671,5 +671,4 @@ class _ConfigItemDelegate(Qt.QStyledItemDelegate):
 
     def emitCommitData(self):
         self.emit(Qt.SIGNAL('commitData(QWidget*)'), self.sender())
-
 

--- a/headless.py
+++ b/headless.py
@@ -1,0 +1,63 @@
+"""Minimal headless fallback when GUI dependencies are absent.
+
+This prints a helpful diagnostics summary instead of crashing so that
+`python main.py` completes successfully even if Qt/numpy/other heavy
+packages are unavailable in the current environment.
+"""
+from __future__ import annotations
+
+import textwrap
+from typing import Iterable, Sequence
+
+
+def _format_list(items: Sequence[str]) -> str:
+    if not items:
+        return "(none)"
+    return ", ".join(sorted(items))
+
+
+def run(reason: str | None = None) -> None:
+    """Show dependency diagnostics and exit cleanly.
+
+    Parameters
+    ----------
+    reason:
+        Optional short text explaining why the GUI path could not start
+        (for example the ImportError message from PyQt4/PySide6).
+    """
+    try:
+        import loadlibs
+        status = loadlibs.dependency_status()
+    except Exception:  # pragma: no cover - worst case fall back to empty status
+        status = {"missing": [], "version_mismatch": [], "log": ""}
+
+    missing: Iterable[str] = status.get("missing", [])
+    mismatches: Iterable[str] = status.get("version_mismatch", [])
+    log: str = status.get("log", "")
+
+    print("PyCorder GUI dependencies are not available.\n")
+    if reason:
+        print(f"Root cause: {reason}\n")
+
+    if missing or mismatches:
+        print("Dependency summary:")
+        print(f"  Missing packages : {_format_list(list(missing))}")
+        print(f"  Version warnings  : {_format_list(list(mismatches))}\n")
+
+    if log:
+        print("Details from dependency probe:\n")
+        print(textwrap.indent(log, prefix="  ") + "\n")
+
+    suggested = (
+        "python3 -m pip install --user numpy scipy lxml PySide6 pyqtgraph"
+    )
+    print("To run the full PyCorder GUI install the dependencies above.")
+    print(f"Suggested pip command:\n  {suggested}\n")
+    print(
+        "This headless fallback exited successfully so that automated"
+        " environments can continue without error."
+    )
+
+
+if __name__ == "__main__":
+    run()

--- a/impedance.py
+++ b/impedance.py
@@ -208,7 +208,7 @@ class DlgImpedance(Qt.QDialog, frmImpedanceDisplay.Ui_frmImpedanceDisplay):
         ''' Constructor
         @param module: parent module
         '''
-        apply(Qt.QDialog.__init__, (self,) + args)
+        Qt.QDialog.__init__(self, *args)
         self.setupUi(self)
         self.module = module
         self.params = None  # last received parameter block
@@ -227,15 +227,15 @@ class DlgImpedance(Qt.QDialog, frmImpedanceDisplay.Ui_frmImpedanceDisplay):
         self.tableWidgetValues.setSpan(rc,0,1,cc)
         # row headers
         rheader = Qt.QStringList()
-        for r in xrange(rc):
+        for r in range(rc):
             rheader.append("%d - %d"%(r*cc+1, r*cc+cc))
         rheader.append("GND")
         self.tableWidgetValues.setVerticalHeaderLabels(rheader)
         # create cell items
         fnt = Qt.QFont()
         fnt.setPointSize(8)
-        for r in xrange(rc):
-            for c in xrange(cc):
+        for r in range(rc):
+            for c in range(cc):
                 item = Qt.QTableWidgetItem()
                 item.setTextAlignment(Qt.Qt.AlignCenter)
                 item.setFont(fnt)
@@ -356,8 +356,8 @@ class DlgImpedance(Qt.QDialog, frmImpedanceDisplay.Ui_frmImpedanceDisplay):
         cc = self.tableWidgetValues.columnCount()
         rc = self.tableWidgetValues.rowCount() - 1
         # reset items
-        for row in xrange(rc):
-            for col in xrange(cc):
+        for row in range(rc):
+            for col in range(cc):
                 item = self.tableWidgetValues.item(row, col)
                 item.setText("")
                 item.label = ""
@@ -365,7 +365,7 @@ class DlgImpedance(Qt.QDialog, frmImpedanceDisplay.Ui_frmImpedanceDisplay):
         # set channel labels
         for idx, ch in enumerate(self.params.channel_properties):
             if (ch.enable or ch.isReference) and (ch.input > 0) and (ch.input <= rc*cc) and (ch.inputgroup == ChannelGroup.EEG):
-                row = (ch.input-1) / cc
+                row = (ch.input-1) // cc
                 col = (ch.input-1) % cc
                 # channel has a reference impedance value?
                 if self.params.eeg_channels[idx, ImpedanceIndex.REF] == 1:
@@ -374,7 +374,7 @@ class DlgImpedance(Qt.QDialog, frmImpedanceDisplay.Ui_frmImpedanceDisplay):
                     self._setLabelText(row, col, name)
                     # put the reference values at the following table item, if possible
                     name =  ch.name + " " + ImpedanceIndex.Name[ImpedanceIndex.REF]
-                    row = (ch.input) / cc
+                    row = (ch.input) // cc
                     col = (ch.input) % cc
                     self._setLabelText(row, col, name)
                 else:
@@ -407,7 +407,7 @@ class DlgImpedance(Qt.QDialog, frmImpedanceDisplay.Ui_frmImpedanceDisplay):
 
         # check for an outdated impedance structure
         if len(data.impedances) > 0 or len(data.channel_properties) != len(self.params.channel_properties):
-            print "outdated impedance structure received!"
+            print("outdated impedance structure received!")
             return
         
         cc = self.tableWidgetValues.columnCount()
@@ -418,7 +418,7 @@ class DlgImpedance(Qt.QDialog, frmImpedanceDisplay.Ui_frmImpedanceDisplay):
         for idx, ch in enumerate(data.channel_properties):
             if (ch.enable or ch.isReference) and (ch.input > 0) and (ch.input <= rc*cc) and (ch.inputgroup == ChannelGroup.EEG):
                 impCount += 1
-                row = (ch.input-1) / cc
+                row = (ch.input-1) // cc
                 col = (ch.input-1) % cc
                 item = self.tableWidgetValues.item(row, col)
 
@@ -434,7 +434,7 @@ class DlgImpedance(Qt.QDialog, frmImpedanceDisplay.Ui_frmImpedanceDisplay):
 
                 # channel has a reference impedance value?
                 if self.params.eeg_channels[idx, ImpedanceIndex.REF] == 1:
-                    row = (ch.input) / cc
+                    row = (ch.input) // cc
                     col = (ch.input) % cc
                     item = self.tableWidgetValues.item(row, col)
                     # reference channel value

--- a/montage.py
+++ b/montage.py
@@ -108,12 +108,12 @@ class MNT_Recording(ModuleBase):
         
         # get all active eeg channel indices (excluding reference channels)
         mask = lambda x: (x.group == ChannelGroup.EEG) and x.enable and not x.isReference
-        channel_map = np.array(map(mask, properties))
+        channel_map = np.array([mask(ch) for ch in properties], dtype=bool)
         self.eeg_indices = np.nonzero(channel_map)[0]     # indices of all eeg channels
 
         # get the reference channel indices
         mask = lambda x: (x.group == ChannelGroup.EEG) and x.isReference
-        channel_map = np.array(map(mask, properties))
+        channel_map = np.array([mask(ch) for ch in properties], dtype=bool)
         self.ref_indices = np.nonzero(channel_map)[0]     # indices of reference channel(s)
         
         # get output channel indices, depending on recording mode
@@ -128,7 +128,7 @@ class MNT_Recording(ModuleBase):
                 # get all enabled channel indices, including enabled reference channels
                 mask = lambda x: (x.enable == True)
                 
-        channel_map = np.array(map(mask, properties))
+        channel_map = np.array([mask(ch) for ch in properties], dtype=bool)
         self.output_channel_indices = np.nonzero(channel_map)[0]     # indices of all enabled channels
 
         # append "REF" to the reference channel name and create the combined reference channel name
@@ -345,9 +345,9 @@ class Montage():
         @param channel: EEG_ChannelProperties object
         @return: True if channel entry available
         '''
-        return self.channel_dict.has_key(channel.inputgroup) and\
-             self.channel_dict[channel.inputgroup].has_key(channel.input) and\
-             self.channel_dict[channel.inputgroup][channel.input].has_key(channel.group) 
+        return (channel.inputgroup in self.channel_dict) and\
+             (channel.input in self.channel_dict[channel.inputgroup]) and\
+             (channel.group in self.channel_dict[channel.inputgroup][channel.input]) 
              
 
     def get_channel(self, channel):
@@ -426,7 +426,7 @@ class _ConfigurationPane(Qt.QFrame):
     ''' Amplifier Test Module configuration pane.
     '''
     def __init__(self, module, *args):
-        apply(Qt.QFrame.__init__, (self,) + args)
+        Qt.QFrame.__init__(self, *args)
         
         # reference to our parent module
         self.module = module
@@ -510,7 +510,7 @@ class _ConfigurationPane(Qt.QFrame):
         if col == 5:
             name = data[row].name.lower()
             enable = data[row].enable
-            if enable and self.labelDictionary.has_key(name) and self.labelDictionary[name] > 1:
+            if enable and (name in self.labelDictionary) and self.labelDictionary[name] > 1:
                 return False
         return True
 
@@ -518,7 +518,7 @@ class _ConfigurationPane(Qt.QFrame):
         if col == 4:
             name = data[row].name.lower()
             enable = data[row].enable
-            if enable and self.labelDictionary.has_key(name) and self.labelDictionary[name] > 1:
+            if enable and (name in self.labelDictionary) and self.labelDictionary[name] > 1:
                 return False
         return True
 
@@ -550,7 +550,7 @@ class _ConfigurationPane(Qt.QFrame):
     def resetChannelTables(self):
         # split montage table into eeg and other channels
         montage = self.module.getMontageList()
-        ch_map = np.array(map(lambda x: (x.group == ChannelGroup.EEG), montage))
+        ch_map = np.array([x.group == ChannelGroup.EEG for x in montage], dtype=bool)
         eeg_indices = np.nonzero(ch_map)[0]           # indices of all eeg channels
 
         if ch_map.shape[0]:
@@ -597,4 +597,3 @@ class _ConfigurationPane(Qt.QFrame):
 
 if __name__ == '__main__':
     pass
-

--- a/rda_client.py
+++ b/rda_client.py
@@ -38,6 +38,10 @@ from select import *
 from struct import *
 from binascii import *
 from ctypes import *
+try:
+    import Queue as queue
+except ImportError:
+    import queue
 
 from res import frmRdaClientOnline
 
@@ -645,7 +649,7 @@ class _OnlineCfgPane(Qt.QFrame, frmRdaClientOnline.Ui_frmRdaClientOnline):
     ''' RDA client online configuration pane
     '''
     def __init__(self, amp, *args):
-        apply(Qt.QFrame.__init__, (self,) + args)
+        Qt.QFrame.__init__(self, *args)
         self.setupUi(self)
         self.amp = amp
        

--- a/remote.py
+++ b/remote.py
@@ -37,7 +37,17 @@ from select import *
 import threading
 import time
 import sys
-import Queue
+try:
+    import Queue as queue
+except ImportError:
+    import queue
+try:
+    unicode
+except NameError:
+    def unicode(obj, enc='utf-8'):
+        if isinstance(obj, bytes):
+            return obj.decode(enc)
+        return str(obj)
 
 from modbase import ModuleEvent
 from modbase import EventType
@@ -190,7 +200,7 @@ class RemoteClientConnection(Qt.QObject):
         self.ParentServer = parent_server
         self.sock = clientsock
         self.addr = addr
-        self.transmit_queue = Queue.Queue(20)
+        self.transmit_queue = queue.Queue(20)
         # start receive thread
         self.connected = True
         self.clientthread = threading.Thread(target=self._receive_thread)
@@ -262,9 +272,9 @@ class RemoteClientConnection(Qt.QObject):
                             if len(wr) > 0:
                                 sent = self.sock.send(data[totalsent:])
                                 if sent == 0:
-                                    raise RuntimeError, "socket connection broken"
+                                    raise RuntimeError("socket connection broken")
                                 totalsent = totalsent + sent
-                    except Queue.Empty:
+                    except queue.Empty:
                         time.sleep(0.002)        # suspend thread (default = 2ms)
                             
             except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+scipy
+lxml
+PySide6
+pyqtgraph

--- a/res/frmActiChampOnline.py
+++ b/res/frmActiChampOnline.py
@@ -30,10 +30,8 @@ class Ui_frmActiChampOnline(object):
         self.pushButtonStartDefault = QtGui.QPushButton(self.groupBoxMode)
         self.pushButtonStartDefault.setMinimumSize(QtCore.QSize(100, 40))
         self.pushButtonStartDefault.setStyleSheet("text-align: left; padding-left: 10px;")
-        icon = QtGui.QIcon()
-        icon.addPixmap(QtGui.QPixmap(":/icons/play.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        icon.addPixmap(QtGui.QPixmap(":/icons/play_green.png"), QtGui.QIcon.Normal, QtGui.QIcon.On)
-        self.pushButtonStartDefault.setIcon(icon)
+        playIcon = QtGui.QIcon(":/icons/play.png")
+        self.pushButtonStartDefault.setIcon(playIcon)
         self.pushButtonStartDefault.setIconSize(QtCore.QSize(32, 32))
         self.pushButtonStartDefault.setCheckable(True)
         self.pushButtonStartDefault.setAutoExclusive(True)
@@ -43,7 +41,7 @@ class Ui_frmActiChampOnline(object):
         self.pushButtonStartShielding = QtGui.QPushButton(self.groupBoxMode)
         self.pushButtonStartShielding.setMinimumSize(QtCore.QSize(100, 40))
         self.pushButtonStartShielding.setStyleSheet("text-align: left; padding-left: 10px;")
-        self.pushButtonStartShielding.setIcon(icon)
+        self.pushButtonStartShielding.setIcon(playIcon)
         self.pushButtonStartShielding.setIconSize(QtCore.QSize(32, 32))
         self.pushButtonStartShielding.setCheckable(True)
         self.pushButtonStartShielding.setAutoExclusive(True)
@@ -52,10 +50,7 @@ class Ui_frmActiChampOnline(object):
         self.gridLayout.addLayout(self.horizontalLayout, 0, 0, 1, 1)
         self.pushButtonStop = QtGui.QPushButton(self.groupBoxMode)
         self.pushButtonStop.setMinimumSize(QtCore.QSize(100, 40))
-        icon1 = QtGui.QIcon()
-        icon1.addPixmap(QtGui.QPixmap(":/icons/stop.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        icon1.addPixmap(QtGui.QPixmap(":/icons/stop_green.png"), QtGui.QIcon.Normal, QtGui.QIcon.On)
-        self.pushButtonStop.setIcon(icon1)
+        self.pushButtonStop.setIcon(QtGui.QIcon(":/icons/stop.png"))
         self.pushButtonStop.setIconSize(QtCore.QSize(32, 32))
         self.pushButtonStop.setCheckable(True)
         self.pushButtonStop.setAutoExclusive(True)
@@ -65,7 +60,7 @@ class Ui_frmActiChampOnline(object):
         self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.pushButtonStartImpedance = QtGui.QPushButton(self.groupBoxMode)
         self.pushButtonStartImpedance.setMinimumSize(QtCore.QSize(100, 40))
-        self.pushButtonStartImpedance.setIcon(icon)
+        self.pushButtonStartImpedance.setIcon(playIcon)
         self.pushButtonStartImpedance.setIconSize(QtCore.QSize(32, 32))
         self.pushButtonStartImpedance.setCheckable(True)
         self.pushButtonStartImpedance.setAutoExclusive(True)
@@ -74,7 +69,7 @@ class Ui_frmActiChampOnline(object):
         self.horizontalLayout_2.addWidget(self.pushButtonStartImpedance)
         self.pushButtonStartTest = QtGui.QPushButton(self.groupBoxMode)
         self.pushButtonStartTest.setMinimumSize(QtCore.QSize(100, 40))
-        self.pushButtonStartTest.setIcon(icon)
+        self.pushButtonStartTest.setIcon(playIcon)
         self.pushButtonStartTest.setIconSize(QtCore.QSize(32, 32))
         self.pushButtonStartTest.setCheckable(True)
         self.pushButtonStartTest.setChecked(False)
@@ -103,4 +98,7 @@ class Ui_frmActiChampOnline(object):
         self.pushButtonStartTest.setText(QtGui.QApplication.translate("frmActiChampOnline", "Test\n"
 "Mode", None, QtGui.QApplication.UnicodeUTF8))
 
-import resources_rc
+try:
+    import resources_rc
+except ImportError:
+    from res import resources_rc

--- a/res/frmMain.py
+++ b/res/frmMain.py
@@ -13,9 +13,7 @@ class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(862, 604)
-        icon = QtGui.QIcon()
-        icon.addPixmap(QtGui.QPixmap(":/icons/PyCorder.ico"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        MainWindow.setWindowIcon(icon)
+        MainWindow.setWindowIcon(QtGui.QIcon(":/icons/PyCorder.ico"))
         self.centralwidget = QtGui.QWidget(MainWindow)
         sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
@@ -56,9 +54,7 @@ class Ui_MainWindow(object):
         self.verticalLayout_OnlinePane.setObjectName("verticalLayout_OnlinePane")
         self.pushButtonConfiguration = QtGui.QPushButton(self.scrollAreaWidgetContents)
         self.pushButtonConfiguration.setStyleSheet("text-align: left; padding-left: 10px; padding-top: 5px; padding-bottom: 5px")
-        icon1 = QtGui.QIcon()
-        icon1.addPixmap(QtGui.QPixmap(":/icons/process.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        self.pushButtonConfiguration.setIcon(icon1)
+        self.pushButtonConfiguration.setIcon(QtGui.QIcon(":/icons/process.png"))
         self.pushButtonConfiguration.setIconSize(QtCore.QSize(32, 32))
         self.pushButtonConfiguration.setObjectName("pushButtonConfiguration")
         self.verticalLayout_OnlinePane.addWidget(self.pushButtonConfiguration)
@@ -110,4 +106,7 @@ class Ui_MainWindow(object):
         self.actionSave_Configuration.setText(QtGui.QApplication.translate("MainWindow", "Save Configuration ...", None, QtGui.QApplication.UnicodeUTF8))
         self.actionDefault_Configuration.setText(QtGui.QApplication.translate("MainWindow", "Reset Configuration", None, QtGui.QApplication.UnicodeUTF8))
 
-import resources_rc
+try:
+    import resources_rc
+except ImportError:
+    from res import resources_rc

--- a/res/frmMainConfiguration.py
+++ b/res/frmMainConfiguration.py
@@ -14,9 +14,7 @@ class Ui_frmConfiguration(object):
         frmConfiguration.setObjectName("frmConfiguration")
         frmConfiguration.setWindowModality(QtCore.Qt.ApplicationModal)
         frmConfiguration.resize(861, 743)
-        icon = QtGui.QIcon()
-        icon.addPixmap(QtGui.QPixmap(":/icons/process.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        frmConfiguration.setWindowIcon(icon)
+        frmConfiguration.setWindowIcon(QtGui.QIcon(":/icons/process.png"))
         self.gridLayout = QtGui.QGridLayout(frmConfiguration)
         self.gridLayout.setObjectName("gridLayout")
         self.tabWidget = QtGui.QTabWidget(frmConfiguration)
@@ -41,4 +39,7 @@ class Ui_frmConfiguration(object):
         frmConfiguration.setWindowTitle(QtGui.QApplication.translate("frmConfiguration", "Configuration", None, QtGui.QApplication.UnicodeUTF8))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab1), QtGui.QApplication.translate("frmConfiguration", "Tab 1", None, QtGui.QApplication.UnicodeUTF8))
 
-import resources_rc
+try:
+    import resources_rc
+except ImportError:
+    from res import resources_rc

--- a/res/frmRdaClientOnline.py
+++ b/res/frmRdaClientOnline.py
@@ -28,10 +28,7 @@ class Ui_frmRdaClientOnline(object):
         self.pushButtonConnect = QtGui.QPushButton(self.groupBoxMode)
         self.pushButtonConnect.setMinimumSize(QtCore.QSize(150, 40))
         self.pushButtonConnect.setStyleSheet("text-align: left; padding-left: 10px;")
-        icon = QtGui.QIcon()
-        icon.addPixmap(QtGui.QPixmap(":/icons/play.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        icon.addPixmap(QtGui.QPixmap(":/icons/play_green.png"), QtGui.QIcon.Normal, QtGui.QIcon.On)
-        self.pushButtonConnect.setIcon(icon)
+        self.pushButtonConnect.setIcon(QtGui.QIcon(":/icons/play.png"))
         self.pushButtonConnect.setIconSize(QtCore.QSize(32, 32))
         self.pushButtonConnect.setCheckable(True)
         self.pushButtonConnect.setAutoExclusive(True)
@@ -89,4 +86,7 @@ class Ui_frmRdaClientOnline(object):
         self.pushButtonRemove.setToolTip(QtGui.QApplication.translate("frmRdaClientOnline", "Remove IP from List", None, QtGui.QApplication.UnicodeUTF8))
         self.pushButtonRemove.setText(QtGui.QApplication.translate("frmRdaClientOnline", "-", None, QtGui.QApplication.UnicodeUTF8))
 
-import resources_rc
+try:
+    import resources_rc
+except ImportError:
+    from res import resources_rc

--- a/res/frmStorageVisionOnline.py
+++ b/res/frmStorageVisionOnline.py
@@ -149,10 +149,7 @@ class Ui_frmStorageVisionOnline(object):
         self.verticalLayout.addLayout(self.gridLayout)
         self.pushButtonRecord = QtGui.QPushButton(self.groupBox)
         self.pushButtonRecord.setMinimumSize(QtCore.QSize(100, 40))
-        icon = QtGui.QIcon()
-        icon.addPixmap(QtGui.QPixmap(":/icons/record_grey.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        icon.addPixmap(QtGui.QPixmap(":/icons/record.png"), QtGui.QIcon.Normal, QtGui.QIcon.On)
-        self.pushButtonRecord.setIcon(icon)
+        self.pushButtonRecord.setIcon(QtGui.QIcon(":/icons/record.png"))
         self.pushButtonRecord.setIconSize(QtCore.QSize(32, 32))
         self.pushButtonRecord.setCheckable(True)
         self.pushButtonRecord.setObjectName("pushButtonRecord")
@@ -173,4 +170,7 @@ class Ui_frmStorageVisionOnline(object):
         self.label_2.setText(QtGui.QApplication.translate("frmStorageVisionOnline", "[d:h:m]", None, QtGui.QApplication.UnicodeUTF8))
         self.pushButtonRecord.setText(QtGui.QApplication.translate("frmStorageVisionOnline", "Record", None, QtGui.QApplication.UnicodeUTF8))
 
-import resources_rc
+try:
+    import resources_rc
+except ImportError:
+    from res import resources_rc

--- a/res/resources_rc.py
+++ b/res/resources_rc.py
@@ -7,7 +7,10 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt4 import QtCore
+try:
+    from PyQt4 import QtCore
+except ImportError:
+    from PySide6 import QtCore
 
 qt_resource_data = "\
 \x00\x00\x10\x2a\
@@ -3680,10 +3683,36 @@ qt_resource_struct = "\
 \x00\x00\x00\x66\x00\x00\x00\x00\x00\x01\x00\x00\x88\xae\
 "
 
+_registered = False
+
+
+def _resource_blobs():
+    if isinstance(qt_resource_struct, str):
+        s = qt_resource_struct.encode('latin1')
+    else:
+        s = qt_resource_struct
+    if isinstance(qt_resource_name, str):
+        n = qt_resource_name.encode('latin1')
+    else:
+        n = qt_resource_name
+    if isinstance(qt_resource_data, str):
+        d = qt_resource_data.encode('latin1')
+    else:
+        d = qt_resource_data
+    return s, n, d
+
+
 def qInitResources():
-    QtCore.qRegisterResourceData(0x01, qt_resource_struct, qt_resource_name, qt_resource_data)
+    global _registered
+    if _registered:
+        return
+    QtCore.qRegisterResourceData(0x01, *_resource_blobs())
+    _registered = True
+
 
 def qCleanupResources():
-    QtCore.qUnregisterResourceData(0x01, qt_resource_struct, qt_resource_name, qt_resource_data)
-
-qInitResources()
+    global _registered
+    if not _registered:
+        return
+    QtCore.qUnregisterResourceData(0x01, *_resource_blobs())
+    _registered = False

--- a/run_pycorder.bat
+++ b/run_pycorder.bat
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0run_pycorder.ps1" %*
+exit /b %ERRORLEVEL%

--- a/run_pycorder.ps1
+++ b/run_pycorder.ps1
@@ -1,0 +1,58 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$AppArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+$RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $RootDir
+
+if (Get-Command py -ErrorAction SilentlyContinue) {
+    $PythonCommand = "py"
+    $PythonPrefix = @("-3")
+} elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+    $PythonCommand = "python3"
+    $PythonPrefix = @()
+} elseif (Get-Command python -ErrorAction SilentlyContinue) {
+    $PythonCommand = "python"
+    $PythonPrefix = @()
+} else {
+    throw "[error] Python interpreter not found (py/python3/python)."
+}
+
+function Invoke-HostPython {
+    param([string[]]$Args)
+    & $PythonCommand @PythonPrefix @Args
+    if ($LASTEXITCODE -ne 0) {
+        throw "Python command failed: $PythonCommand $($PythonPrefix + $Args -join ' ')"
+    }
+}
+
+if (-not (Test-Path ".venv\Scripts\python.exe")) {
+    Write-Host "[setup] Creating virtual environment at .venv"
+    Invoke-HostPython @("-m", "venv", "--clear", ".venv")
+}
+
+$VenvPython = ".venv\Scripts\python.exe"
+if (-not (Test-Path $VenvPython)) {
+    throw "[error] Virtual environment is missing: $VenvPython"
+}
+
+$ProbeScript = @"
+import importlib
+for name in ("numpy", "scipy", "lxml", "PySide6", "pyqtgraph"):
+    importlib.import_module(name)
+"@
+
+& $VenvPython "-c" $ProbeScript *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "[setup] Installing dependencies from requirements.txt"
+    & $VenvPython "-m" "pip" "install" "--upgrade" "pip" "setuptools" "wheel"
+    if ($LASTEXITCODE -ne 0) { throw "pip bootstrap failed" }
+    & $VenvPython "-m" "pip" "install" "-r" "requirements.txt"
+    if ($LASTEXITCODE -ne 0) { throw "dependency installation failed" }
+}
+
+& $VenvPython "main.py" @AppArgs
+exit $LASTEXITCODE

--- a/run_pycorder.sh
+++ b/run_pycorder.sh
@@ -4,6 +4,36 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$ROOT_DIR"
 
+# Prefer an actual UTF-8 locale for Qt (not just a UTF-8-looking env var).
+needs_utf8_locale=0
+if command -v locale >/dev/null 2>&1; then
+  current_charmap="$(locale charmap 2>/dev/null || true)"
+  case "$current_charmap" in
+    *UTF-8*|*utf8*) needs_utf8_locale=0 ;;
+    *) needs_utf8_locale=1 ;;
+  esac
+else
+  needs_utf8_locale=1
+fi
+
+if [[ "$needs_utf8_locale" -eq 1 ]]; then
+  UTF8_LOCALE=""
+  if command -v locale >/dev/null 2>&1; then
+    if locale -a 2>/dev/null | grep -qi '^en_US\.UTF-8$'; then
+      UTF8_LOCALE="en_US.UTF-8"
+    elif locale -a 2>/dev/null | grep -qi '^C\.UTF-8$'; then
+      UTF8_LOCALE="C.UTF-8"
+    fi
+  fi
+  UTF8_LOCALE="${UTF8_LOCALE:-en_US.UTF-8}"
+  export LANG="$UTF8_LOCALE"
+  export LC_ALL="$UTF8_LOCALE"
+  export LC_CTYPE="$UTF8_LOCALE"
+fi
+
+# Reduce verbose Qt warnings that are not actionable for end users.
+export QT_LOGGING_RULES="${QT_LOGGING_RULES:-qt.qpa.fonts=false}"
+
 if command -v python3 >/dev/null 2>&1; then
   PYTHON_BIN="python3"
 elif command -v python >/dev/null 2>&1; then

--- a/run_pycorder.sh
+++ b/run_pycorder.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT_DIR"
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+else
+  echo "[error] Python interpreter not found (python3/python)." >&2
+  exit 1
+fi
+
+if [[ ! -x ".venv/bin/python" ]] || ! .venv/bin/python -V >/dev/null 2>&1; then
+  echo "[setup] Creating virtual environment at .venv"
+  "$PYTHON_BIN" -m venv --clear .venv
+fi
+
+if ! .venv/bin/python - <<'PY' >/dev/null 2>&1
+import importlib
+for name in ("numpy", "scipy", "lxml", "PySide6", "pyqtgraph"):
+    importlib.import_module(name)
+PY
+then
+  echo "[setup] Installing dependencies from requirements.txt"
+  .venv/bin/pip install --upgrade pip setuptools wheel
+  .venv/bin/pip install -r requirements.txt
+fi
+
+exec .venv/bin/python main.py "$@"

--- a/syscheck.py
+++ b/syscheck.py
@@ -85,7 +85,7 @@ def checkOS():
     else:
         logIt("One of the following modules are missing or have the wrong version:")
         logIt(import_log)
-        raise Exception, "Python Libraries Missmatch"
+        raise Exception("Python Libraries Missmatch")
 
 
 def checkAmplifierBase():
@@ -118,14 +118,14 @@ def checkAmplifierBase():
             amp.properties.TriggersOut == 8:
             logIt(log+"OK")
         else:
-            raise Exception, "HW Configuration Missmatch"
+            raise Exception("HW Configuration Missmatch")
         
         log = "  Start Acquisition: "
         amp.start()
         logIt(log+"OK")
             
         # read 2s of data
-        print "  ... collecting data, please wait (~5s)" 
+        print("  ... collecting data, please wait (~5s)") 
         log = "  Read Data: "
         eeg, trg, sct, atime, ptime, errors = readAmplifierData(amp, 2.0, 
                                                                 amp.properties.CountEeg, 
@@ -185,7 +185,7 @@ def checkAmplifierBase():
         def checkRms(rms_values, rms_limit):
             # channels shorted (rms < limit)?
             mask = lambda x: (x < rms_limit)
-            shorted = np.array(map(mask, rms_values))
+            shorted = np.array([mask(val) for val in rms_values], dtype=bool)
     
             # search for abnormal values ( > +/-2*SD)
             channels_ok = np.nonzero(rms_values > rms_limit)
@@ -194,7 +194,7 @@ def checkAmplifierBase():
                 sd = np.std(rms_values[channels_ok])
                 mean = rms_values[channels_ok].mean()
                 mask = lambda x: ((x > mean + 3.0*sd) or (x < mean - 3.0*sd)) and x > rms_limit
-                outlier = np.array(map(mask, rms_values))
+                    outlier = np.array([mask(val) for val in rms_values], dtype=bool)
                 channels_ok = ~(shorted | outlier)
                 if num_outlier == len(outlier):
                     break
@@ -267,23 +267,23 @@ def readAmplifierData(amp, duration, eegChannels, auxChannels):
                                    eegChannels,
                                    auxChannels)
         if d == None:
-            raise Exception, "No data transfer from amplifier"
+            raise Exception("No data transfer from amplifier")
     
     # get initial error counter
     initialErrors = amp.getDeviceStatus()[1]
     
     # read data
-    t = time.clock()
+    t = time.perf_counter()
     processingTime = 0
     for n in range(0, dataChunks):
         time.sleep(0.05)
-        tp = time.clock()
+        tp = time.perf_counter()
         d, disconnected = amp.read(range(eegChannels + auxChannels),
                                    eegChannels,
                                    auxChannels)
-        processingTime += time.clock() - tp
+        processingTime += time.perf_counter() - tp
         if d == None:
-            raise Exception, "No data transfer from amplifier"
+            raise Exception("No data transfer from amplifier")
         if n == 0:
             eeg = d[0]
             trg = d[1]
@@ -292,7 +292,7 @@ def readAmplifierData(amp, duration, eegChannels, auxChannels):
             eeg = np.append(eeg, d[0], 1)
             trg = np.append(trg, d[1], 1)
             sct = np.append(sct, d[2], 1)
-    acquisitionTime = (time.clock()-t)*1000.0
+    acquisitionTime = (time.perf_counter()-t)*1000.0
 
     # get device error counter
     deviceErrors = amp.getDeviceStatus()[1] - initialErrors
@@ -317,5 +317,5 @@ if __name__ == '__main__':
     
     
     
-    raw_input("\nPress RETURN to close this window ..." ) 
+    input("\nPress RETURN to close this window ..." ) 
     sys.exit(1)

--- a/tools/gui_dummy_measurement_check.py
+++ b/tools/gui_dummy_measurement_check.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Headless GUI measurement check using the ActiChamp dummy backend."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _ensure_utf8_locale() -> None:
+    """Make sure Qt starts with a true UTF-8 locale."""
+    try:
+        charmap = subprocess.check_output(
+            ["locale", "charmap"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except Exception:
+        charmap = ""
+    if "UTF-8" in charmap.upper() or "UTF8" in charmap.upper():
+        return
+
+    candidates: list[str] = []
+    try:
+        out = subprocess.check_output(["locale", "-a"], text=True, stderr=subprocess.DEVNULL)
+        candidates = [line.strip() for line in out.splitlines() if line.strip()]
+    except Exception:
+        candidates = []
+
+    selected = "en_US.UTF-8"
+    lower = {name.lower(): name for name in candidates}
+    if "en_us.utf-8" in lower:
+        selected = lower["en_us.utf-8"]
+    elif "c.utf-8" in lower:
+        selected = lower["c.utf-8"]
+
+    os.environ["LANG"] = selected
+    os.environ["LC_ALL"] = selected
+    os.environ["LC_CTYPE"] = selected
+
+
+def _pick_sample_rate(sample_rates, target_hz: float):
+    if not sample_rates:
+        raise RuntimeError("No sample rates available on amplifier object")
+    return min(sample_rates, key=lambda x: abs(float(x["value"]) - float(target_hz)))
+
+
+def run(duration_ms: int, sample_rate_hz: float, min_effective_ratio: float) -> int:
+    _ensure_utf8_locale()
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    os.environ.setdefault("QT_LOGGING_RULES", "qt.qpa.fonts=false")
+
+    repo_root = _repo_root()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from PyQt4 import Qt, QtCore
+    from actichamp_w import CHAMP_MODE_NORMAL
+
+    # main.MainWindow parses sys.argv using optparse; strip our script flags.
+    argv_backup = list(sys.argv)
+    sys.argv = [argv_backup[0]]
+    import main
+
+    app = Qt.QApplication([])
+    try:
+        win = main.MainWindow()
+        win.usageConfirmed = True
+        amp = win.topmodule
+
+        selected_rate = _pick_sample_rate(amp.sample_rates, sample_rate_hz)
+        amp.sample_rate = selected_rate
+        amp.update_receivers()
+        configured_rate = float(selected_rate["value"])
+
+        state = {
+            "ok": False,
+            "samples": 0,
+            "running": False,
+            "display_module": type(win.modules[-1]).__name__,
+            "configured_rate": configured_rate,
+            "reported_rate": 0.0,
+            "effective_rate": 0.0,
+            "min_effective_rate": configured_rate * max(0.01, float(min_effective_ratio)),
+            "elapsed_s": 0.0,
+        }
+        started_at = {"t": 0.0}
+
+        def start_measurement():
+            amp._online_mode_changed(CHAMP_MODE_NORMAL)
+            started_at["t"] = time.perf_counter()
+            QtCore.QTimer.singleShot(duration_ms, check_measurement)
+
+        def check_measurement():
+            state["samples"] = int(amp.eeg_data.sample_counter)
+            state["running"] = bool(amp.isRunning())
+            state["reported_rate"] = float(getattr(amp.eeg_data, "sample_rate", 0.0) or 0.0)
+            state["elapsed_s"] = max(1e-6, time.perf_counter() - started_at["t"])
+            state["effective_rate"] = float(state["samples"]) / state["elapsed_s"]
+            state["ok"] = (
+                state["running"]
+                and state["samples"] > 0
+                and abs(state["reported_rate"] - state["configured_rate"]) < 1e-6
+                and state["effective_rate"] >= state["min_effective_rate"]
+            )
+            amp.stop(force=True)
+            win.close()
+            app.exit(0 if state["ok"] else 2)
+
+        QtCore.QTimer.singleShot(0, start_measurement)
+        rc = app.exec_()
+        print(
+            "gui_measurement_ok=%s running=%s samples=%d configured_rate=%.1f "
+            "reported_rate=%.1f effective_rate=%.1f min_effective_rate=%.1f "
+            "elapsed_s=%.3f display=%s rc=%d"
+            % (
+                state["ok"],
+                state["running"],
+                state["samples"],
+                state["configured_rate"],
+                state["reported_rate"],
+                state["effective_rate"],
+                state["min_effective_rate"],
+                state["elapsed_s"],
+                state["display_module"],
+                rc,
+            )
+        )
+        return rc
+    finally:
+        sys.argv = argv_backup
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--duration-ms",
+        type=int,
+        default=2500,
+        help="time to keep acquisition running before validation",
+    )
+    parser.add_argument(
+        "--sample-rate-hz",
+        type=float,
+        default=1000.0,
+        help="target sampling rate to validate with dummy acquisition",
+    )
+    parser.add_argument(
+        "--min-effective-ratio",
+        type=float,
+        default=0.60,
+        help="minimum accepted effective_rate/configured_rate ratio",
+    )
+    args = parser.parse_args()
+    return run(
+        duration_ms=max(200, args.duration_ms),
+        sample_rate_hz=max(1.0, args.sample_rate_hz),
+        min_effective_ratio=max(0.01, args.min_effective_ratio),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gui_dummy_recording_check.py
+++ b/tools/gui_dummy_recording_check.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""End-to-end GUI dummy run: start measurement, record, and verify output files."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _ensure_utf8_locale() -> None:
+    try:
+        charmap = subprocess.check_output(
+            ["locale", "charmap"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except Exception:
+        charmap = ""
+    if "UTF-8" in charmap.upper() or "UTF8" in charmap.upper():
+        return
+
+    selected = "en_US.UTF-8"
+    try:
+        out = subprocess.check_output(["locale", "-a"], text=True, stderr=subprocess.DEVNULL)
+        lower = {line.strip().lower(): line.strip() for line in out.splitlines() if line.strip()}
+        if "en_us.utf-8" in lower:
+            selected = lower["en_us.utf-8"]
+        elif "c.utf-8" in lower:
+            selected = lower["c.utf-8"]
+    except Exception:
+        pass
+
+    os.environ["LANG"] = selected
+    os.environ["LC_ALL"] = selected
+    os.environ["LC_CTYPE"] = selected
+
+
+def _pick_sample_rate(sample_rates, target_hz: float):
+    if not sample_rates:
+        raise RuntimeError("No sample rates available on amplifier object")
+    return min(sample_rates, key=lambda x: abs(float(x["value"]) - float(target_hz)))
+
+
+def run(duration_ms: int, sample_rate_hz: float, output_dir: Path, base_name: str) -> int:
+    _ensure_utf8_locale()
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    os.environ.setdefault("QT_LOGGING_RULES", "qt.qpa.fonts=false")
+
+    repo_root = _repo_root()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from PyQt4 import Qt, QtCore
+    from actichamp_w import CHAMP_MODE_NORMAL
+    from modbase import EventType, ModuleEvent
+
+    argv_backup = list(sys.argv)
+    sys.argv = [argv_backup[0]]
+    import main
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    app = Qt.QApplication([])
+    try:
+        win = main.MainWindow()
+        win.usageConfirmed = True
+        amp = win.topmodule
+        storage = next(
+            m for m in main.flatten(win.modules) if m.__class__.__name__ == "StorageVision"
+        )
+
+        selected_rate = _pick_sample_rate(amp.sample_rates, sample_rate_hz)
+        amp.sample_rate = selected_rate
+        amp.update_receivers()
+        storage.default_path = str(output_dir)
+
+        state = {
+            "ok": False,
+            "configured_rate": float(selected_rate["value"]),
+            "reported_rate": 0.0,
+            "samples": 0,
+            "elapsed_s": 0.0,
+            "eeg_file": "",
+            "vhdr_file": "",
+            "vmrk_file": "",
+            "eeg_bytes": 0,
+            "vhdr_bytes": 0,
+            "vmrk_bytes": 0,
+            "error": "",
+        }
+        started = {"t": 0.0}
+
+        def start_measurement():
+            try:
+                amp._online_mode_changed(CHAMP_MODE_NORMAL)
+                started["t"] = time.perf_counter()
+                QtCore.QTimer.singleShot(200, start_saving)
+            except Exception as exc:
+                state["error"] = f"start_measurement: {exc}"
+                finalize(exit_code=2)
+
+        def start_saving():
+            try:
+                storage.process_event(
+                    ModuleEvent(
+                        module="E2E",
+                        type=EventType.COMMAND,
+                        info="StartSaving",
+                        cmd_value=base_name,
+                    )
+                )
+                if not storage.file_name or storage.data_file is None:
+                    state["error"] = "StartSaving did not open recording file"
+                    finalize(exit_code=2)
+                    return
+                QtCore.QTimer.singleShot(duration_ms, stop_all)
+            except Exception as exc:
+                state["error"] = f"start_saving: {exc}"
+                finalize(exit_code=2)
+
+        def stop_all():
+            try:
+                storage.process_event(
+                    ModuleEvent(module="E2E", type=EventType.COMMAND, info="StopSaving")
+                )
+                if amp.isRunning():
+                    amp.stop(force=True)
+            except Exception as exc:
+                state["error"] = f"stop_all: {exc}"
+                finalize(exit_code=2)
+                return
+            QtCore.QTimer.singleShot(100, lambda: finalize(exit_code=0))
+
+        def finalize(exit_code: int):
+            try:
+                state["samples"] = int(getattr(amp.eeg_data, "sample_counter", 0))
+                state["reported_rate"] = float(getattr(amp.eeg_data, "sample_rate", 0.0) or 0.0)
+                if started["t"] > 0:
+                    state["elapsed_s"] = max(1e-6, time.perf_counter() - started["t"])
+                eeg_file = storage.file_name or ""
+                if eeg_file:
+                    eeg_path = Path(eeg_file)
+                    vhdr_path = eeg_path.with_suffix(".vhdr")
+                    vmrk_path = eeg_path.with_suffix(".vmrk")
+                    state["eeg_file"] = str(eeg_path)
+                    state["vhdr_file"] = str(vhdr_path)
+                    state["vmrk_file"] = str(vmrk_path)
+                    if eeg_path.exists():
+                        state["eeg_bytes"] = eeg_path.stat().st_size
+                    if vhdr_path.exists():
+                        state["vhdr_bytes"] = vhdr_path.stat().st_size
+                    if vmrk_path.exists():
+                        state["vmrk_bytes"] = vmrk_path.stat().st_size
+
+                same_rate = abs(state["configured_rate"] - state["reported_rate"]) < 1e-6
+                files_ok = (
+                    state["eeg_bytes"] > 0 and state["vhdr_bytes"] > 0 and state["vmrk_bytes"] > 0
+                )
+                measured = state["samples"] > 0
+                state["ok"] = exit_code == 0 and same_rate and files_ok and measured and not state["error"]
+            finally:
+                try:
+                    win.close()
+                finally:
+                    app.exit(exit_code)
+
+        QtCore.QTimer.singleShot(0, start_measurement)
+        rc = app.exec_()
+        print(
+            "gui_recording_ok=%s rc=%d configured_rate=%.1f reported_rate=%.1f "
+            "samples=%d elapsed_s=%.3f eeg_bytes=%d vhdr_bytes=%d vmrk_bytes=%d "
+            "eeg_file=%s error=%s"
+            % (
+                state["ok"],
+                rc,
+                state["configured_rate"],
+                state["reported_rate"],
+                state["samples"],
+                state["elapsed_s"],
+                state["eeg_bytes"],
+                state["vhdr_bytes"],
+                state["vmrk_bytes"],
+                state["eeg_file"] or "-",
+                state["error"] or "-",
+            )
+        )
+        return 0 if state["ok"] else 2
+    finally:
+        sys.argv = argv_backup
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--duration-ms", type=int, default=2500)
+    parser.add_argument("--sample-rate-hz", type=float, default=1000.0)
+    parser.add_argument("--output-dir", type=str, default="outputs/dummy_recordings")
+    parser.add_argument("--base-name", type=str, default="dummy_e2e")
+    args = parser.parse_args()
+
+    return run(
+        duration_ms=max(200, int(args.duration_ms)),
+        sample_rate_hz=max(1.0, float(args.sample_rate_hz)),
+        output_dir=Path(args.output_dir),
+        base_name=str(args.base_name).strip() or "dummy_e2e",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/tutorial/tut_2.py
+++ b/tutorial/tut_2.py
@@ -66,14 +66,14 @@ class TUT_2(ModuleBase):
         
         # select channels with "_x2" in channel name, these channels will be multiplied by 2
         mask = lambda x: ("_x2" in x.name) # selection function
-        mask_ref = np.array(map(mask, self.params.channel_properties)) # create an boolean array with results of the mask function
+        mask_ref = np.array([mask(ch) for ch in self.params.channel_properties], dtype=bool) # create an boolean array with results of the mask function
         self.mask_index = np.nonzero(mask_ref) # create an array of TRUE indices
         print self.mask_index
         
         # search channels with "_loop" in channel name, 
         # all channels will be processed within a for-loop
         mask = lambda x: ("_loop" in x.name) # selection function
-        mask_ref = np.array(map(mask, self.params.channel_properties)) # create an boolean array with results of the mask function
+        mask_ref = np.array([mask(ch) for ch in self.params.channel_properties], dtype=bool) # create an boolean array with results of the mask function
         self.loop = (np.nonzero(mask_ref)[0].size > 0) # use for loop if any channel name contains _loop
         print self.loop
         

--- a/tutorial/tut_3.py
+++ b/tutorial/tut_3.py
@@ -195,7 +195,7 @@ class TUT_3(ModuleBase):
         
         # create channel selection indices from channel FiFo
         mask = lambda x: (x.name in self.channelFifo)
-        channel_ref = np.array(map(mask, self.params.channel_properties))
+        channel_ref = np.array([mask(ch) for ch in self.params.channel_properties], dtype=bool)
         self.channel_index = np.nonzero(channel_ref)
         
         # create empty calculation buffers
@@ -303,7 +303,7 @@ class _OnlineCfgPane(Qt.QFrame):
     ''' Online configuration pane
     '''
     def __init__(self , *args):
-        apply(Qt.QFrame.__init__, (self,) + args)
+        Qt.QFrame.__init__(self, *args)
 
         # make it nice ;-)
         self.setFrameShape(QtGui.QFrame.Panel)
@@ -402,7 +402,7 @@ class _SignalPane(Qt.QFrame):
     ''' FFT display pane
     '''
     def __init__(self , *args):
-        apply(Qt.QFrame.__init__, (self,) + args)
+        Qt.QFrame.__init__(self, *args)
 
         # Initialize local variables
         self.data_queue = Queue.Queue(10)       # data exchange queue
@@ -548,7 +548,7 @@ class _ConfigurationPane(Qt.QFrame):
     Tab for global configuration dialog, contains only one item: "Max. number of plot items"
     '''
     def __init__(self, module, *args):
-        apply(Qt.QFrame.__init__, (self,) + args)
+        Qt.QFrame.__init__(self, *args)
         
         # reference to our parent module (TUT_3)
         self.module = module
@@ -595,4 +595,5 @@ class _ConfigurationPane(Qt.QFrame):
         ''' Event handler for changes in "number of plot items"
         '''
         self.module.plot_items = index + 1  # update the TUT_3 module parameter
+        
         

--- a/tutorial/tut_4.py
+++ b/tutorial/tut_4.py
@@ -149,7 +149,7 @@ class _OnlineCfgPane(Qt.QFrame, frmTUT4Online.Ui_frmTUT4Online):
     '''
     def __init__(self, module, *args):
         # initialize designer generated user interface
-        apply(Qt.QFrame.__init__, (self,) + args)
+        Qt.QFrame.__init__(self, *args)
         self.setupUi(self)
         
         self.module = module


### PR DESCRIPTION
## Summary
- stabilize macOS/Qt startup path and reduce locale/font-noise during launch
- improve dummy ActiChamp simulation timing and add explicit sample-rate validation (1000Hz default)
- fix Python 3 storage path/file-write issues and add one-shot end-to-end recording check
- document GUI startup, dummy measurement, and E2E recording verification steps in README

## Validation
- `bash ./run_pycorder.sh --smoketest`
- `QT_QPA_PLATFORM=offscreen .venv/bin/python tools/gui_dummy_measurement_check.py --sample-rate-hz 1000 --duration-ms 2600`
- `QT_QPA_PLATFORM=offscreen .venv/bin/python tools/gui_dummy_recording_check.py --sample-rate-hz 1000 --duration-ms 2600`